### PR TITLE
sample: Add sample application using I2C driver

### DIFF
--- a/sample/i2c/CMakeLists.txt
+++ b/sample/i2c/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Space Cubics, LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(i2c-sample)
+
+target_sources(app PRIVATE src/main.c)

--- a/sample/i2c/prj.conf
+++ b/sample/i2c/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_I2C=y

--- a/sample/i2c/src/main.c
+++ b/sample/i2c/src/main.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Space Cubics, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/i2c.h>
+
+#define TMP175_I2C_ADDR (0x4F)
+#define TMP175_TEMP_REG (0x00)
+
+int main(void)
+{
+	int ret;
+	uint8_t data[2];
+	float temp;
+
+	const struct device *i2c = DEVICE_DT_GET(DT_NODELABEL(i2c0));
+
+	ret = i2c_burst_read(i2c, TMP175_I2C_ADDR, TMP175_TEMP_REG, data, ARRAY_SIZE(data));
+	if (ret < 0) {
+		printf("Failed to read from Temperature Sensor (%d)\n", ret);
+		goto end;
+	}
+
+	data[1] = data[1] >> 4;
+	temp = (int8_t)data[0] + (float)data[1] * 0.0625f;
+
+	printf("Temperature: %.4f [deg]\n", (double)temp);
+
+end:
+	return ret;
+}


### PR DESCRIPTION
This application reads temperature data from a TMP175 temperature sensor connected via external I2C and prints the values to the console.